### PR TITLE
changes for campaign reader as well as for adios 2.10 Python API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # XGC_reader
 Python script for XGC data analysis
+
+Requires adios 2.10 or newer

--- a/xgc_distribution.py
+++ b/xgc_distribution.py
@@ -115,7 +115,7 @@ class XGCDistribution:
     #initialize from adios2 file like xgc.f0.00000.bp
     @classmethod
     def from_xgc_output(cls, filename, var_string='i_f', dir = './', time_step = 0, mass_au=2.0, charge_num = 1.0, has_electron=True, use_initial_moments=False):
-        with adios2.open(dir+'/'+filename,"rra") as file:
+        with adios2.FileReader(dir+'/'+filename) as file:
             it=time_step
             ftmp=file.read(var_string,start=[],count=[],step_start=it, step_count=1)
             print('Reading data with shape:',np.shape(ftmp))
@@ -129,7 +129,7 @@ class XGCDistribution:
             nvpara = int((ftmp.shape[2]-1)/2)
             nnodes=ftmp.shape[0]
 
-        with adios2.open(dir + 'xgc.f0.mesh.bp',"rra") as file:
+        with adios2.FileReader(dir + 'xgc.f0.mesh.bp') as file:
             vp_max = file.read('f0_vp_max')
             smu_max = file.read('f0_smu_max')
             vgrid = VelocityGrid(nvperp, nvpara, smu_max, vp_max)
@@ -171,7 +171,7 @@ class XGCDistribution:
     #initialize from distribution input file -- same format as that of save()
     @classmethod
     def from_xgc_input(cls, filename):
-        with adios2.open(filename, "rra") as fr:
+        with adios2.FileReader(filename) as fr:
             f_g = fr.read("f_g")
             den = fr.read("density")
             temp_ev = fr.read("temperature")
@@ -335,7 +335,7 @@ class XGCDistribution:
         if(self.has_maxwellian):
             self.remove_maxwellian()
 
-        with adios2.open(filename, mode='w') as fw:
+        with adios2.Stream(filename, mode='w') as fw:
             adios2_write_array(fw, "f_g", self.f_g) # maxwellian component is removed.
             adios2_write_array(fw, "density", self.den)
             adios2_write_array(fw, "temperature", self.temp_ev)


### PR DESCRIPTION
Tested for xgc_reader.py so far with this code below for a campaign, but it also keeps reading for a directory (initialized as before like `x=xgc_reader.xgc1('./')`)
```
import os
import xgc_reader
import numpy as np
import adios2

x=xgc_reader.xgc1('csc143/xgc/n560.aca')
x.load_units()
x.setup_mesh()
x.setup_f0mesh()
x.load_oned()

x.print_plasma_info()

#read f3d
#step=x.od.step[-1]
step=58
f=x.campaign
prefix='xgc.f3d.%5.5d.bp/'%step
print(f"Read data from {prefix}")
e_T_para=np.mean(f.read(prefix+'e_T_para'),axis=1)
e_T_perp=np.mean(f.read(prefix+'e_T_perp'),axis=1)
i_T_para=np.mean(f.read(prefix+'i_T_para'),axis=1)
i_T_perp=np.mean(f.read(prefix+'i_T_perp'),axis=1)
time=f.read(prefix+'time')
```