### PR TITLE
`dpot` to be printed even after `remove_boltzmann()`

### DIFF
--- a/xgc_distribution.py
+++ b/xgc_distribution.py
@@ -374,6 +374,7 @@ class XGCDistribution:
             fw.write("nnodes", np.array([self.nnodes], dtype=np.int32))
             if(self.has_boltzmann):
                 adios2_write_array(fw, "density_with_boltzmann", self.density_with_boltzmann) # This needs only for electron
+            if hasattr(self, "dpot"):
                 adios2_write_array(fw, "dpot", self.dpot) # This needs only for electron
 
     # zero out f_g 


### PR DESCRIPTION
When generating `f_g` for XGC1 from XGCa for electrons, we are removing boltzmann contribution by executing `remove_boltzmann()` after constructing `XGCDistribution`.

`remove_boltzmann()` makes `has_boltzmann = False`, so `dpot` will not be printed out after this. But we need `dpot` to be stored somewhere to be used for `get_f0_ptl` in `initialize_particles.cpp` of XGC1.

This PR is an ad-hoc fix for this, but maybe it'd be better to have a separate flag like `is_electron`, but I want to avoid having too many flags (`has_boltzmann`, `has_maxwellian`, ...) so ended up with the implementation like this.